### PR TITLE
Fix test cases related to identity and role binding

### DIFF
--- a/controller_test.go
+++ b/controller_test.go
@@ -156,30 +156,6 @@ func (suite *ControllerTestSuite) TestBindAckWithInvalidSignature() {
 	suite.Equal(err, "invalid binding ack signature")
 }
 
-func (suite *ControllerTestSuite) TestBitcoinRPCWithoutBinding() {
-	ownerDID := "did:key:zQ3shvD5cZSLggSCiu4jmF3jRY6GMUb7zvwChfhYQGJfQudJE"
-
-	c := Controller{
-		bindingFile: BindingFile,
-		ownerDID:    ownerDID,
-		Identity:    suite.Identity,
-	}
-
-	b := c.bitcoinRPC(ownerDID, BitcoindRPCParams{
-		Method: "getblockchaininfo",
-		Params: json.RawMessage(`[]`),
-	})
-
-	resp := map[string]json.RawMessage{}
-	suite.NoError(json.Unmarshal(b, &resp))
-	suite.Nil(resp["data"])
-	suite.NotNil(resp["error"])
-
-	var err string
-	suite.NoError(json.Unmarshal(resp["error"], &err))
-	suite.Equal(err, "node is not bound")
-}
-
 func TestControllerTestSuite(t *testing.T) {
 	i, err := NewPodIdentity()
 	if err != nil {

--- a/identity_test.go
+++ b/identity_test.go
@@ -72,7 +72,7 @@ func (suite *PodIdentityTestSuite) TestCreateOrLoadPodIdentityWithExistingKey() 
 
 func (suite *PodIdentityTestSuite) TestCreateOrLoadPodIdentityWithoutExistingKey() {
 	i, created, err := CreateOrLoadPodIdentityFromKey(suite.KeyFile)
-	suite.False(created)
+	suite.True(created)
 	suite.NoError(err)
 
 	keyBytes, err := os.ReadFile(suite.KeyFile)


### PR DESCRIPTION
- Fix incorrect assertion for identity_test.
- Remove a binding related test case for RPC since the binding check is moved out.