### PR TITLE
Improve the websocket connection and auth token expiry

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/bitmark-inc/secp256k1-go v0.0.0-20210301070431-3d05e3361433
 	github.com/btcsuite/btcd v0.21.0-beta.0.20210413192109-2d7825cf709f
 	github.com/btcsuite/btcutil v1.0.3-0.20201208143702-a53e38424cce
+	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/golang/mock v1.5.0
 	github.com/google/uuid v1.2.0
 	github.com/gorilla/websocket v1.4.2

--- a/go.sum
+++ b/go.sum
@@ -64,6 +64,7 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/decred/dcrd/lru v1.0.0/go.mod h1:mxKOwFd7lFjN2GZYsiz/ecgqR6kkYAl+0pz0tEMk218=
+github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=

--- a/main.go
+++ b/main.go
@@ -2,10 +2,14 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"flag"
 	"net/http"
+	"os"
+	"os/signal"
 	"time"
 
+	jwt "github.com/dgrijalva/jwt-go"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 
@@ -18,6 +22,9 @@ type RequestCommand struct {
 	Command string          `json:"command"`
 	Args    json.RawMessage `json:"args"`
 }
+
+// renewBefore: 10 minutes in seconds
+var renewBefore = 10 * time.Minute / time.Second
 
 func main() {
 	var configFile string
@@ -39,35 +46,92 @@ func main() {
 		WithField("created", created).
 		Info("controller initialized")
 
-	jwt, err := i.Auth()
-	if err != nil {
+	interrupt := make(chan os.Signal, 1)
+	signal.Notify(interrupt, os.Interrupt)
+
+	if err := i.Auth(); err != nil {
 		log.WithError(err).Panic("pod authentication fail")
 	}
 
-	messagingClient := messaging.New(
-		&http.Client{Timeout: 10 * time.Second},
-		viper.GetString("messaging.endpoint"),
-		jwt,
-		config.AbsoluteApplicationFilePath(viper.GetString("messaging.db_name")))
+	// The goroutine will continuously check auth_token and re-request a new one if
+	// a token is going to be expired.
+	go func(checkInterval time.Duration) {
+		for {
+			token := i.AuthToken()
+			if token == "" {
+				// wait for the first token to be acquired from the first authentication
+				time.Sleep(time.Second)
+				continue
+			}
 
-	if err := messagingClient.RegisterAccount(); err != nil {
-		log.Fatalf("registering account, error: %s", err)
-	}
+			// parse the jwt claim without verified the token signature
+			t, _, err := new(jwt.Parser).ParseUnverified(token, &jwt.StandardClaims{})
+			if err != nil {
+				log.WithError(err).Panic("fail to refresh token")
+			}
 
-	if err := messagingClient.RegisterKeys(); err != nil {
-		log.WithError(err).Fatalf("failed to register keys")
-	}
+			if claims, ok := t.Claims.(*jwt.StandardClaims); ok {
+				if time.Now().Unix() > (claims.ExpiresAt - int64(renewBefore)) {
+					if err := i.Auth(); err != nil {
+						log.WithError(err).Panic("fail to refresh token")
+					}
+					log.Info("successfully refresh a new token")
+				} else {
+					log.WithField("expires_at", claims.ExpiresAt).Debug("token not expired")
+				}
+				time.Sleep(checkInterval)
+				continue
+			} else {
+				log.WithError(errors.New("error casting token claims")).Panic("fail to refresh token")
+			}
+		}
+	}(time.Minute)
 
-	ws, err := messagingClient.NewWSClient()
-	if err != nil {
-		log.WithError(err).Panic("fail to establish websocket connection")
-	}
+CONNECTION_LOOP:
+	// This is the main loop for maintaining a persistant websocket connection to API server
+	for {
+		authToken := i.AuthToken()
 
-	for m := range ws.WhisperMessages() {
-		log.WithField("message", m).Debug("receive message")
-		responseMessage := controller.Process(m)
-		if responseMessage != nil {
-			ws.SendWhisperMessages(m.Source, m.SourceDevice, responseMessage)
+		messagingClient := messaging.New(
+			&http.Client{Timeout: 10 * time.Second},
+			viper.GetString("messaging.endpoint"),
+			authToken,
+			config.AbsoluteApplicationFilePath(viper.GetString("messaging.db_name")))
+
+		if err := messagingClient.RegisterAccount(); err != nil {
+			log.Fatalf("registering account, error: %s", err)
+		}
+
+		if err := messagingClient.RegisterKeys(); err != nil {
+			log.WithError(err).Fatalf("failed to register pre-keys on startup")
+		}
+
+		ws, err := messagingClient.NewWSClient()
+		if err != nil {
+			log.WithError(err).Panic("fail to establish websocket connection")
+		}
+
+		// This is a loop to watch and process new messages
+		for {
+			select {
+			case <-interrupt:
+				log.Info("service interrupted")
+				ws.Close()
+				break CONNECTION_LOOP
+			case m := <-ws.WhisperMessages():
+				// there will be a very last nil message if a connection is closed from the server
+				if m == nil {
+					log.Info("connection closed by server")
+					ws.Close()
+					break CONNECTION_LOOP
+				}
+
+				log.WithField("message", m).Debug("receive message")
+				responseMessage := controller.Process(m)
+				if responseMessage != nil {
+					ws.SendWhisperMessages(m.Source, m.SourceDevice, responseMessage)
+				}
+			}
 		}
 	}
 }

--- a/messaging/client.go
+++ b/messaging/client.go
@@ -55,6 +55,11 @@ func New(httpClient *http.Client, endpoint, jwt, storePath string) *Client {
 	}
 }
 
+// RefreshToken updates current authToken with a new value
+func (c *Client) RefreshToken(authToken string) {
+	c.authToken = authToken
+}
+
 func (c *Client) RegisterAccount() error {
 	registrationID, err := c.identityStore.GetLocalRegistrationID()
 	if err != nil {


### PR DESCRIPTION
In this PR, we do

1. improve the connection stability by set up a new loop for re-establishing websocket connection
2. add a goroutine to examine the auth_token and re-request a new one before it is expired
3. add a goroutine to refill pre-keys 