### PR TITLE
Add a retry mechanism to solve process terminating issue

### DIFF
--- a/messaging/client.go
+++ b/messaging/client.go
@@ -25,6 +25,7 @@ const (
 type PrivateKeyStore interface {
 	StoreIdentityKeyPair(*axolotl.IdentityKeyPair) error
 	StoreRegistrationID(uint32) error
+	Close() error
 }
 
 type Client struct {
@@ -299,6 +300,11 @@ func (c *Client) ReceiveMessages() ([]*Message, bool, error) {
 	}
 
 	return decryptedMessages, more, nil
+}
+
+// Close will terminate the client gracefully
+func (c *Client) Close() error {
+	return c.privateKeyStore.Close()
 }
 
 func generateRegistrationID() uint32 {

--- a/messaging/store.go
+++ b/messaging/store.go
@@ -23,6 +23,11 @@ func newLevelDBAxolotlStore(path string) *LevelDBAxolotlStore {
 	return s
 }
 
+// Close is to close the database
+func (l *LevelDBAxolotlStore) Close() error {
+	return l.db.Close()
+}
+
 //
 func (l *LevelDBAxolotlStore) StoreIdentityKeyPair(kp *axolotl.IdentityKeyPair) error {
 	data := make([]byte, 64)


### PR DESCRIPTION
In this PR, it introduces a retry mechanism to address the issue that the whole process terminated when the connection is closed by remote.

Notable changes:

- Add a close function to `LevelDBAxolotlStore` so that the MessagingClient could be re-initiate without blocking by the DB file.
- Add two parameter for setting retry interval and retry counts.

Reference Issue: https://github.com/bitmark-inc/autonomy/issues/548
