### PR TITLE
Create a subcommand to set up pod identity

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,9 @@ RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache
 
 FROM alpine:3.10.3
 ARG dist=0.0
+
+RUN apk add --no-cache curl
+
 COPY --from=build /go/bin/autonomy-pod-controller /autonomy-pod-controller
 
 ADD config.yaml.sample /.config/pod_controller.yaml

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,9 @@ default: build
 pod-controller:
 	go build -o bin/pod-controller
 
+init-pod-controller: pod-controller
+	./bin/pod-controller -c config.yaml init
+
 run-pod-controller: pod-controller
 	./bin/pod-controller -c config.yaml
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,16 @@ bitcoind via whisper protocol.
 make pod-controller
 ```
 
+## Initialize
+
+Every pod controller has its own identity. It normally set up before a pod is running. Here is a subcommand to set it up before hand:
+
+```
+make init-pod-controller
+```
+
+It will return its pod identity. You can use it for pairing with your Autonomy client.
+
 ## Run
 
 First, create a `config.yaml` by copy `config.yaml.sample` and configure it properly. Then run:

--- a/main.go
+++ b/main.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"errors"
 	"flag"
+	"fmt"
 	"net/http"
 	"os"
 	"os/signal"
@@ -48,6 +49,14 @@ func main() {
 	i, created, err := CreateOrLoadPodIdentityFromKey(config.AbsoluteApplicationFilePath(viper.GetString("auth_key_file")))
 	if err != nil {
 		log.WithError(err).Panic("fail to create or load identity")
+	}
+
+	command := flag.Arg(0)
+	switch command {
+	case "init":
+		fmt.Println(i.DID)
+		return
+	default:
 	}
 
 	ownerDID := viper.GetString("owner_did")


### PR DESCRIPTION
In this PR, it introduces a new subcommand for initialize the pod identity if it does not. The command returns the DID of a pod. It can be used to register back to the Autonomy API server.